### PR TITLE
Added could-not-authorize-user.md file in Errors and Resolutions section

### DIFF
--- a/docs/errors/could-not-authorize-user.md
+++ b/docs/errors/could-not-authorize-user.md
@@ -1,0 +1,42 @@
+---
+id: could-not-authorize-user
+title: Could not authorize user
+sidebar_label: Could not authorize user
+slug: /errors/could-not-authorize-user
+---
+
+# Could not authorize user
+
+## Message
+
+»   Error: Could not authorize user
+
+## What went wrong?
+
+Amplication CLI works with the hosted version on https://app.amplication.com. It's possible that you might have run the command 
+
+```$ amp config:set AMP_SERVER_URL http://localhost:3000```
+
+while going through the documentation.
+
+
+## What to do?
+
+Please run the command `amp config`. You should get below output stating AMP_SERVER_URL=http://localhost:3000/
+
+AMP_CURRENT_APP=undefined
+AMP_CURRENT_ENTITY=undefined
+AMP_CURRENT_FIELD=undefined
+AMP_SERVER_URL=http://localhost:3000/
+AMP_OUTPUT_FORMAT=undefined
+
+This means that AMP_SERVER_URL is set to http://localhost:3000/ We need to set the URL to https://app.amplication.com.
+
+Run the below command to resolve this issue.
+
+```$ amp config:set AMP_SERVER_URL https://app.amplication.com```
+
+After running the above command the issue should be resolved. Post which you may run the command `amp auth TOKEN` with the token generated from the Amplication server UI.
+
+
+


### PR DESCRIPTION
Hi, @yuval-hazaz I have added a file `could-not-authorize-user.md` file at path `docs\docs\errors` folder. This was an issue that I faced sometimes back and I thought it might be helpful if I add the resolution steps for the issue.

