### PR TITLE
Update links on product roadmap page

### DIFF
--- a/docs/about/product-roadmap.md
+++ b/docs/about/product-roadmap.md
@@ -7,7 +7,7 @@ slug: /about/roadmap
 
 # Product Roadmap
 
-View the official [Amplication public product roadmap](https://www.notion.so/190845345cb04a2ea15b4f4cce3a05ae).
+View the official [Amplication public product roadmap](https://amplication.notion.site/190845345cb04a2ea15b4f4cce3a05ae).
 
 As an open-source platform, Amplication is committed to a policy of complete transparency with our community about our future direction. Use our product roadmap to learn about our future plans, to see what we're working on and what's coming next.
 By sharing our roadmap, we hope you will become an even closer partner in our joint vision of building and extending a platform that will empower professional developers to create business applications.
@@ -16,9 +16,9 @@ By sharing our roadmap, we hope you will become an even closer partner in our jo
 
 Select a view as follows:
 
-- [Board by Status](https://www.notion.so/190845345cb04a2ea15b4f4cce3a05ae)
-- [Board by Area](https://www.notion.so/190845345cb04a2ea15b4f4cce3a05ae)
-- [Table View](https://www.notion.so/190845345cb04a2ea15b4f4cce3a05ae)
+- [Board by Status](https://amplication.notion.site/190845345cb04a2ea15b4f4cce3a05ae?v=4fd4da56afd8478dbcccadce4059bcc9)
+- [Board by Area](https://amplication.notion.site/190845345cb04a2ea15b4f4cce3a05ae?v=292e393cbd564628ab4117eb3f7d8c45)
+- [Table View](https://amplication.notion.site/190845345cb04a2ea15b4f4cce3a05ae?v=da666b7936fb41e1b1da4a2150505b28)
 
 To respond to an item in the Amplication Public Roadmap, click the GitHub link in the item.
 


### PR DESCRIPTION
Direct links to Notion.so documents were in the old format without a subdomain.

This behaviour was changed in July 2021.
Source: https://www.notion.so/blog/personalize-public-pages