### PR TITLE
fix: avoid jumping menu item when it is collapsing

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -78,8 +78,6 @@
 }
 
 .menu__list-item {
-  margin-bottom: 0;
-  margin-top: 2px;
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
I thought it was the Docusaurus bug, but actually such a jump lag happens because of the added margin in custom CSS, I think it is better to remove it.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4408379/194721114-bc129ecc-e1fa-40ec-8b09-3359ec2020ae.gif)


Note how a small jump lag starts before the Welcome item when it is collapsing/expanding.