### PR TITLE
Bug Fix: Correcting the Next Link to Accurately Reference the Bitbucket Article

### DIFF
--- a/docs/running-amplication-platform/connect-server-to-github.md
+++ b/docs/running-amplication-platform/connect-server-to-github.md
@@ -3,6 +3,7 @@ id: connect-server-to-github
 title: Connect Amplication server to GitHub
 sidebar_label: Connect Amplication server to GitHub
 slug: /running-amplication-platform/connect-server-to-github
+pagination_next: running-amplication-platform/connect-server-to-bitbucket
 ---
 
 # Connect Amplication server to GitHub


### PR DESCRIPTION
(docs): Fixing the bug and making sure that the next link properly points to the Bitbucket article.