### PR TITLE
Docs: Start Now Button Fix

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -204,3 +204,8 @@ article > header {
 }
 
 
+@media only screen and (max-width: 996px) {
+  .start-now-button {
+    display: none; 
+  }
+}


### PR DESCRIPTION
(docs): Just hiding the button on mobile, just like how every other navigation item gets hidden. This way it doesn't overlap the search button.