### PR TITLE
Bug Fix: Get Started Navbar Item Remains Highlighted

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,6 +41,7 @@ module.exports = {
           to: "/",
           position: "left",
           label: "Get Started",
+          activeBaseRegex: '^/$'
         },
         {
           to: "/tutorials",


### PR DESCRIPTION
(docs): Adding a regex so that the Get Started navbar item is only active when the Getting Started page is open.