### PR TITLE
Docs: GraphQL Playground

### DIFF
--- a/docs/getting-started/generated-app-api.md
+++ b/docs/getting-started/generated-app-api.md
@@ -8,11 +8,12 @@ slug: /api
 
 # REST and GraphQL API
 
-Amplication generates production-ready REST and GraphQL APIs with [Swagger UI](https://swagger.io/tools/swagger-ui/) documentation for all your data models. Easily connect to your data with any HTTP client.
+Amplication generates production-ready REST and GraphQL APIs with documentation and playgrounds for all your data models.
+Easily connect to your data with any HTTP client.
 
 ## REST APIs
 
-Amplication generates REST APIs that provide you with a way to interact with your data models. Generated APIs include [authentication and authorization](#authentication) and follow strict RESTful conventions. Each generated REST API also comes with **sorting**, **filtering**, and **pagination** features.
+Amplication generates REST APIs that provide a way to interact with your data models. Generated APIs include [authentication and authorization](#authentication) and follow strict RESTful conventions. Each generated REST API also comes with **sorting**, **filtering**, and **pagination** features.
 
 The REST API is available at `/api` at the root of your application.
 
@@ -58,7 +59,7 @@ It will add the authorization header automatically.
 
 ## GraphQL APIs
 
-Besides REST APIs, Amplication also generates GraphQL APIs as an alternative way to help you interact with your data models. GraphQL APIs also support sorting, filtering, pagination, and **meta queries**.
+Besides REST APIs, Amplication also generates a GraphQL API as an alternative way to help you interact with your data models. The GraphQL API also support sorting, filtering, pagination, and **meta queries**.
 
 The GraphQL API is available at `/graphql` at the root of your application.
 

--- a/docs/getting-started/generated-app-api.md
+++ b/docs/getting-started/generated-app-api.md
@@ -1,47 +1,150 @@
 ---
 id: generated-app-api
-title: Use your APIs
-sidebar_label: Use Your APIs
+title: REST and GraphQL API
+sidebar_label: REST and GraphQL API
 slug: /api
 # The slug of this page should not be changed since it is referenced from the Admin UI sign in page
 ---
 
-# Use Your APIs
+# REST and GraphQL API
 
-Every application created with Amplication is generated with two types of APIs: REST, and GraphQL.
+Amplication generates production-ready REST and GraphQL APIs with [Swagger UI](https://swagger.io/tools/swagger-ui/) documentation for all your data models. Easily connect to your data with any HTTP client.
 
-In this article you will learn how to connect, authenticate, and consume these APIs.
+## REST APIs
 
-## Authentication
+Amplication generates REST APIs that provide you with a way to interact with your data models. Generated APIs include [authentication and authorization](#authentication) and follow strict RESTful conventions. Each generated REST API also comes with **sorting**, **filtering**, and **pagination** features.
 
-To send a request to the API you must provide an authentication header.
+The REST API is available at `/api` at the root of your application.
 
-To learn more about authentication see this [article](/authentication)
+### Sorting
 
-## REST API
+Retrieve data in a specific order by applying sorting to your API requests. Sort data based on different fields in your data model.
 
-The REST API is available at **/api** at the root of your application.
-When you navigate directly to **/api** you will see the swagger documentation of your API with a list of all resources and actions.
+```
+GET /api/posts?orderBy[createdAt]=Asc
+```
 
-For development and testing purposes, you can use the [swagger UI](https://swagger.io/tools/swagger-ui/) to execute requests against the API. First, click on the "Authorize" button and enter the username and password, it will add the authorization header automatically.
+[Learn about sorting](/api/generated-api-sorting/#rest-api) REST API requests.
 
-![](./assets/generated-app-api/swagger-ui.png)
+### Filtering
 
-The REST API provide methods on all your data model. For each model, you can find five endpoints. For example, on the User model you will find the following endpoints:
+Filter data based on specific criteria by using query parameters in your API requests. Combine multiple filters for more specific results.
 
-- `GET /api/users` - to get a list of users
-- `GET /api/users/:id` - to get a single user by its ID
-- `POST /api/users` - to create a new user
-- `PATCH /api/users/:id` - to update an existing user by its ID
-- `DELETE /api/users/:id` - to delete a user by its ID
+```
+GET /api/posts?where[title][contains]=Node.js
+```
 
-## GraphQL API
+[Learn about filtering](/api/generated-api-filtering/#rest-api) REST API requests.
 
-The GraphQL API is available at **/graphql** at the root of your application.
+### Pagination
 
-When you navigate directly to **/graphql** you will see the [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground/) provided by Apollo Server.
+Paginate API results to manage large datasets and provide a better user experience. Use the `skip` and `take` query parameters to control the number of results per page and the starting point.
 
-For development and testing purposes, you can use the GraphQL Playground to execute queries and mutations against the API. First, click on the "HTTP HEADERS" tab at the bottom of the screen and add the authorization header in the following format:
+```
+GET /api/posts?skip=20&take=20
+```
+
+[Learn about paginating](/api/generated-api-pagination/#rest-api) REST API requests.
+
+### Swagger UI 
+
+For development purposes, you can use Swagger UI to execute requests against the API.
+When you navigate directly to `/api` you will see the swagger documentation of your API with a list of all resources and actions.
+
+First, click on the **Authorize** button and enter the username and password. 
+It will add the authorization header automatically.
+
+![Swagger UI](./assets/generated-app-api/swagger-ui.png)
+
+## GraphQL APIs
+
+Besides REST APIs, Amplication also generates GraphQL APIs as an alternative way to help you interact with your data models. GraphQL APIs also support sorting, filtering, pagination, and **meta queries**.
+
+The GraphQL API is available at `/graphql` at the root of your application.
+
+### Sorting
+
+Sort the retrieved data in a specific order by adding sorting arguments to your GraphQL queries. Control the sorting order based on fields defined in your data model.
+
+```
+query{
+  posts(
+    orderBy:{
+      createdAt:Desc
+    }
+  ){
+    id
+    title
+  }
+}
+```
+
+[Learn about sorting](/api/generated-api-sorting/#graphql) GraphQL API requests.
+
+### Filtering
+
+Filter data based on specific criteria by adding filter arguments to your GraphQL queries. Combine multiple filters for more precise results.
+
+```
+query{
+  posts(
+    where:{
+      title:{
+        contains:"Node.js"
+      }
+    }
+  ){
+    id
+    title
+  }
+}
+```
+
+[Learn about filtering](/api/generated-api-filtering/#graphql) GraphQL API requests.
+
+### Pagination
+
+Implement pagination in your GraphQL queries to handle large datasets and improve the user experience. Use the `skip` and `take` arguments to control the number of results and the starting point.
+
+```
+query{
+  posts(
+    skip:20
+    take:20
+  )
+  {
+    id
+    title
+  }
+}
+```
+
+[Learn about paginating](/api/generated-api-pagination/#graphql) GraphQL API requests.
+
+### Meta Queries
+
+Use meta queries to gather additional information about your data, such as the total number of records or the aggregation of certain fields.
+
+```
+query{
+ _customersMeta(where:{
+   firstName:{
+     contains:"jack"
+   }
+ }){
+   count
+ }
+}
+```
+
+[Learn more about meta queries](/api/meta-query-graphql/) with your GraphQL API requests.
+
+### GraphQL Playground
+
+For development purposes, you can use the GraphQL Playground to execute queries and mutations against the API.
+When you navigate directly to `/graphql` you will see the GraphQL Playground provided by Apollo Server.
+
+First, click on the **HTTP HEADERS** tab at the bottom of teh screen and add the authorization header in the following format:
 
 ```
 {
@@ -49,20 +152,18 @@ For development and testing purposes, you can use the GraphQL Playground to exec
 }
 ```
 
-![](./assets/generated-app-api/graphql-playground.png)
+![Swagger UI](./assets/generated-app-api/graphql-playground.png)
 
-The GraphQL API provide queries and mutations on all your data model. For each model, you can find 2 queries and 3 mutations. \
-For example, for the User model you will find the following:
+:::tip
+The GraphQL Playground available at `/graphql` is only available for development.
+If you want to **enable it for production**, set the following two flags to *true*:
 
-### Queries
+- `GRAPHQL_PLAYGROUND`
+- `GRAPHQL_INTROSPECTION`
+:::
 
-- `users` - to get a list of users
-- `user` - to get a single user by its ID
+## Authentication
 
-### Mutations
+Amplication generates authentication mechanisms based on the NestJS/Passport library. It supports various authentication mechanisms like JWT-based authentication and custom authentication with Passport.
 
-- `createUser` - to create a new user
-- `updateUser` - to update an existing user by its ID
-- `deleteUser` - to delete a user by its ID
-
-Click on the DOCS tab on the right hand side to view a full documentation of all queries and mutations.
+[Learn more about authorizing](/authentication/) your API requests.


### PR DESCRIPTION
(docs): Restructuring the `/api` page, adding the GraphQL Playground section to the GraphQL, and the Swagger UI section to the REST APIs section. Making the title 'REST and GraphQL API'