### PR TITLE
Bug Fix: Introduction Page Link To Deploy Page

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -27,7 +27,7 @@ All generated Node.js applications include the following features:
 - [Sync with GitHub](/sync-with-github/)
 - Version Control
 - [Code Generation](/getting-started/view-generated-code/)
-- [Deploy](/how-to/custom-code/) & Publish
+- [Deploy](/deploy/) & Publish
 
 In addition, developers can utilize their skills to [customize the generated application](/how-to/custom-code/) afterwards.
 


### PR DESCRIPTION
(docs): Fixing an incorrect link on the introdution page. Making it go to the correct "Deploy with Docker" page instead.