### PR TITLE
Docs: Update Broken URL and Set Access Permissions Page

### DIFF
--- a/docs/how-to/set-access-permissions.md
+++ b/docs/how-to/set-access-permissions.md
@@ -25,9 +25,9 @@ These actions can be set to one of the following:
 
 ## Set Entity Permissions
 
-1. Click the **Entities** icon in the main menu (left sidebar) to open the _Entities_ page.
-2. Click an entity.
-3. On the entity's page, click **Permissions**.
+1. Click on the **Entities** tab on your dashboard to open the _Entities_ page.
+2. Click on a specific entity.
+3. On the entity's page, click **Permissions** in the left sidebar.
 
    By default, all actions (_View_, _Create_, _Update_, _Delete_, and _Search_) are set to **All Roles**.
 

--- a/docs/premium-features/break-the-monolith.md
+++ b/docs/premium-features/break-the-monolith.md
@@ -130,7 +130,7 @@ The dialog will let you confirm the creation of new services with default settin
 :::note
 Existing entity permissions **do not get moved over** to the new service structure with Break The Monolith. The permissions with your entities will need manual reassignment.
 
-Learn [how to set access permissions](how-to/set-access-permissions/#set-entity-permissions) for your entities.
+Learn [how to set access permissions](/how-to/set-access-permissions/#set-entity-permissions) for your entities.
 :::
 
 After applying changes in the Architecture tab, the "Pending Changes" section of your dashboard will reflect those updates. If everything looks good, click on the **Commit Changes & Build** button and Amplication will automatically create a new PR to your git provider containing your changes towards a micro-services architecture.


### PR DESCRIPTION
(docs): Fixing a broken URL on the /break-the-monolith page and also updating the text on Set Access Permissions given the new UI structure.