### PR TITLE
Docs: .NET Reference `after` function example updates

### DIFF
--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -27,7 +27,7 @@ export type PluginBeforeEvent<T extends EventParams> = (
 ) => Promisable<T>;
 
 // Node.js version
-export type PluginAfterEventNodejs<T extends EventParams> = (
+export type PluginAfterEvent<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T,
   modules: ModuleMap

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -26,18 +26,30 @@ export type PluginBeforeEvent<T extends EventParams> = (
   eventParams: T
 ) => Promisable<T>;
 
-export type PluginAfterEvent<T extends EventParams> = (
+// Node.js version
+export type PluginAfterEventNodejs<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T,
   modules: ModuleMap
 ) => Promisable<ModuleMap>;
+
+// .NET version
+export type PluginAfterEventDotNet<T extends EventParams, F> = (
+  dsgContext: DsgContext,
+  eventParams: T,
+  files: FileMap<F>
+) => Promisable<FileMap<F>>;
 ```
 
 In the `before` and `after` functions, we have an access to the context and the event params.
 The [context](docs\plugins\context.md) is used to gather common parts between events.
 The event params manipulate the default behavior by passing different values.
 
-In the `after` function, we also have access to the generated modules. An example of using this parameter is when you want to restructure the generated modules in a different folder structure.
+In the `after` function, we also have access to the generated files. An example of using this parameter is when you want to restructure the generated files in a different folder structure.
+
+:::info
+In the Node.js DSG, the generated files are mapped to the [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts). For the .NET DSG, the generated files are mapped to [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/index.ts).
+:::
 
 ## Cautionary Guidelines
 

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -34,7 +34,7 @@ export type PluginAfterEvent<T extends EventParams> = (
 ) => Promisable<ModuleMap>;
 
 // .NET version
-export type PluginAfterEventDotNet<T extends EventParams, F> = (
+export type PluginAfterEvent<T extends EventParams, F> = (
   dsgContext: DsgContext,
   eventParams: T,
   files: FileMap<F>

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -26,7 +26,7 @@ export type PluginBeforeEvent<T extends EventParams> = (
   eventParams: T
 ) => Promisable<T>;
 
-// Node.js version
+// Node.js [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/plugins.types.ts#L21)
 export type PluginAfterEvent<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T,

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -9,6 +9,8 @@ slug: /plugins/plugin-events/plugin-events-before-after
 
 All events expose an identical interface with two functions that can be handled by the plugin and responsible for a different step in the lifecycle of the event. One for "before" the event is emitted and another for "after" the event is emitted.
 
+## Event Structure and Parameters
+
 ```tsx
 export interface PluginEventType<T extends EventParams> {
   before?: PluginBeforeEvent<T>;
@@ -20,20 +22,24 @@ For each event, the type of `EventParams` is different, providing access to rele
 
 ```tsx
 export interface EventParams {}
+```
 
+## Before and After Function Signatures
+
+```tsx
 export type PluginBeforeEvent<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T
 ) => Promisable<T>;
 
-// Node.js [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/plugins.types.ts#L21)
+// Node.js version
 export type PluginAfterEvent<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T,
   modules: ModuleMap
 ) => Promisable<ModuleMap>;
 
-// .NET [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/dotnet-plugins.types.ts#L22)
+// .NET version
 export type PluginAfterEvent<T extends EventParams, F> = (
   dsgContext: DsgContext,
   eventParams: T,
@@ -45,13 +51,19 @@ In the `before` and `after` functions, we have an access to the context and the 
 The [context](docs\plugins\context.md) is used to gather common parts between events.
 The event params manipulate the default behavior by passing different values.
 
+## Accessing and Modifying Generated Files
+
 In the `after` function, we also have access to the generated files. An example of using this parameter is when you want to restructure the generated files in a different folder structure.
 
 :::info
 In the `after` function for .NET plugins, we use a [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/file-map.ts). For Node.js plugins' `after` function we use a [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts#L149).
 :::
 
-## Cautionary Guidelines
+## Function Examples
+
+Most of the functions include examples. But, if you're looking for more comprehensive and real-world examples, you can explore the [code of the Amplication plugins](https://github.com/amplication/plugins/tree/master/plugins)directly. These plugins showcase various implementations and use cases for the before and after lifecycle functions.
+
+## Best Practices and Cautions
 
 1. In the `after` function, avoid unintentionally overriding the entire generated file. Opt for smaller changes instead.
 2. In the `before` function, take care when modifying templates to not unintentionally affect code generation.

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -48,7 +48,7 @@ The event params manipulate the default behavior by passing different values.
 In the `after` function, we also have access to the generated files. An example of using this parameter is when you want to restructure the generated files in a different folder structure.
 
 :::info
-In the `after` function for .NET plugins, we use a [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/index.ts). For Node.js plugins' `after` function we use a [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts).
+In the `after` function for .NET plugins, we use a [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/file-map.ts). For Node.js plugins' `after` function we use a [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts#L149).
 :::
 
 ## Cautionary Guidelines

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -61,7 +61,7 @@ In the `after` function for .NET plugins, we use a [`FileMap`](https://github.co
 
 ## Function Examples
 
-Most of the functions include examples. But, if you're looking for more comprehensive and real-world examples, you can explore the [code of the Amplication plugins](https://github.com/amplication/plugins/tree/master/plugins)directly. These plugins showcase various implementations and use cases for the before and after lifecycle functions.
+Most of the functions include examples. But, if you're looking for more comprehensive and real-world examples, you can explore the [code of the Amplication plugins](https://github.com/amplication/plugins/tree/master/plugins) directly. These plugins showcase various implementations and use cases for the before and after lifecycle functions.
 
 ## Best Practices and Cautions
 

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -33,7 +33,7 @@ export type PluginAfterEvent<T extends EventParams> = (
   modules: ModuleMap
 ) => Promisable<ModuleMap>;
 
-// .NET version
+// .NET [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/dotnet-plugins.types.ts#L22)
 export type PluginAfterEvent<T extends EventParams, F> = (
   dsgContext: DsgContext,
   eventParams: T,

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -7,7 +7,7 @@ slug: /plugins/plugin-events/plugin-events-before-after
 
 # Before and After Lifecycle Functions
 
-All events expose an identical interface with two functions that can be handled by the plugin and responsible for a different step in the lifecycle of the event. One for “before” the event is emitted and another for “after” the event is emitted.
+All events expose an identical interface with two functions that can be handled by the plugin and responsible for a different step in the lifecycle of the event. One for "before" the event is emitted and another for "after" the event is emitted.
 
 ```tsx
 export interface PluginEventType<T extends EventParams> {
@@ -48,7 +48,7 @@ The event params manipulate the default behavior by passing different values.
 In the `after` function, we also have access to the generated files. An example of using this parameter is when you want to restructure the generated files in a different folder structure.
 
 :::info
-In the Node.js DSG, the generated files are mapped to the [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts). For the .NET DSG, the generated files are mapped to [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/index.ts).
+In the `after` function for .NET plugins, we use a [`FileMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/files/index.ts). For Node.js plugins' `after` function we use a [`ModuleMap`](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/code-gen-types.ts).
 :::
 
 ## Cautionary Guidelines

--- a/docs/plugins/before-after.md
+++ b/docs/plugins/before-after.md
@@ -32,14 +32,14 @@ export type PluginBeforeEvent<T extends EventParams> = (
   eventParams: T
 ) => Promisable<T>;
 
-// Node.js version
+// Node.js [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/plugins.types.ts#L21)
 export type PluginAfterEvent<T extends EventParams> = (
   dsgContext: DsgContext,
   eventParams: T,
   modules: ModuleMap
 ) => Promisable<ModuleMap>;
 
-// .NET version
+// .NET [version](https://github.com/amplication/amplication/blob/master/libs/util/code-gen-types/src/dotnet-plugins.types.ts#L22)
 export type PluginAfterEvent<T extends EventParams, F> = (
   dsgContext: DsgContext,
   eventParams: T,

--- a/docs/plugins/dotnet-plugin-events/create-dtos.md
+++ b/docs/plugins/dotnet-plugin-events/create-dtos.md
@@ -31,11 +31,11 @@ Example:
 async afterCreateDTOs(
   context: DsgContext,
   eventParams: CreateDTOsParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, dtoName, dtoBasePath } = eventParams;
   const dtoPath = join(dtoBasePath, `${dtoName}.cs`);
-  const dtoFile = modules.get(dtoPath);
+  const dtoFile = files.get(dtoPath);
 
   if (dtoFile) {
     const updatedCode = dtoFile.code + `
@@ -46,12 +46,12 @@ async afterCreateDTOs(
     }
     `;
 
-    modules.set({
+    files.set({
       path: dtoPath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-dtos.md
+++ b/docs/plugins/dotnet-plugin-events/create-dtos.md
@@ -25,33 +25,24 @@ export interface CreateDTOsParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateDTOs(
-  context: DsgContext,
-  eventParams: CreateDTOsParams,
-  files: FileMap<F>
-) {
-  const { entity, dtoName, dtoBasePath } = eventParams;
-  const dtoPath = join(dtoBasePath, `${dtoName}.cs`);
-  const dtoFile = files.get(dtoPath);
-
+afterCreateDTOs(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateDTOsParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const { entity, dtoName } = eventParams;
+  const dtoFile = files.get(`DTOs/${dtoName}.cs`);
   if (dtoFile) {
-    const updatedCode = dtoFile.code + `
-    public class ${entity.name}SummaryDTO
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-    }
-    `;
-
-    files.set({
-      path: dtoPath,
-      code: updatedCode
-    });
+    dtoFile.code.addProperty(
+      CsharpSupport.property({
+        name: "LastModified",
+        type: CsharpSupport.Types.dateTime(),
+      })
+    );
   }
-
   return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-controller-base.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-controller-base.md
@@ -35,27 +35,53 @@ An array of module actions available for the entity.
 
 An array of all entities in the application.
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityControllerBase(
-  context: DsgContext,
-  eventParams: CreateEntityControllerBaseParams,
-  files: FileMap<F>
-) {
-  const { resourceName, apisDir } = eventParams;
-  const controllerBasePath = join(apisDir, `${resourceName}ControllerBase.cs`);
+afterCreateEntityControllerBase(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityControllerBaseParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const { entity, resourceName, apisDir } = eventParams;
+  const controllerBasePath = `${apisDir}/${entity.name}/Base/${pascalCase(entity.name)}ControllerBase.cs`;
   const controllerBaseFile = files.get(controllerBasePath);
 
   if (controllerBaseFile) {
-    const updatedCode = controllerBaseFile.code.replace(
-      "public abstract class",
-      "[ApiController]\n[Route(\"api/[controller]\")]\npublic abstract class"
+    // Add a protected method to the base controller
+    controllerBaseFile.code.addMethod(
+      CsharpSupport.method({
+        name: "ValidateEntityState",
+        access: "protected",
+        returnType: CsharpSupport.Types.boolean(),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "entity",
+            type: CsharpSupport.Types.reference(entity.name),
+          }),
+        ],
+        body: `
+          if (entity == null)
+            return false;
+          
+          // Add custom validation logic here
+          return true;
+        `,
+      })
     );
 
-    files.set({
-      path: controllerBasePath,
-      code: updatedCode
+    // Modify existing methods to use the new validation
+    const methods = controllerBaseFile.code.getMethods();
+    methods.forEach(method => {
+      if (method.name === `Create${entity.name}` || method.name === `Update${entity.name}`) {
+        const existingBody = method.body;
+        method.body = `
+          if (!ValidateEntityState(${camelCase(entity.name)}))
+            return BadRequest("Invalid entity state");
+          
+          ${existingBody}
+        `;
+      }
     });
   }
 

--- a/docs/plugins/dotnet-plugin-events/create-entity-controller-base.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-controller-base.md
@@ -41,11 +41,11 @@ Example:
 async afterCreateEntityControllerBase(
   context: DsgContext,
   eventParams: CreateEntityControllerBaseParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { resourceName, apisDir } = eventParams;
   const controllerBasePath = join(apisDir, `${resourceName}ControllerBase.cs`);
-  const controllerBaseFile = modules.get(controllerBasePath);
+  const controllerBaseFile = files.get(controllerBasePath);
 
   if (controllerBaseFile) {
     const updatedCode = controllerBaseFile.code.replace(
@@ -53,12 +53,12 @@ async afterCreateEntityControllerBase(
       "[ApiController]\n[Route(\"api/[controller]\")]\npublic abstract class"
     );
 
-    modules.set({
+    files.set({
       path: controllerBasePath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-controller.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-controller.md
@@ -42,28 +42,43 @@ The directory where the API controllers are being generated.
 
 An object containing the CRUD actions available for the entity.
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityController(
-  context: DsgContext,
-  eventParams: CreateEntityControllerParams,
-  files: FileMap<F>
-) {
+afterCreateEntityController(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityControllerParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
   const { entity, resourceName, apisDir } = eventParams;
-  const controllerPath = join(apisDir, `${resourceName}Controller.cs`);
+  const controllerPath = `${apisDir}/${entity.name}/${pascalCase(entity.name)}Controller.cs`;
   const controllerFile = files.get(controllerPath);
 
   if (controllerFile) {
-    const updatedCode = controllerFile.code.replace(
-      "public class",
-      "[ApiVersion(\"1.0\")]\npublic class"
+    // Add a custom action to the controller
+    controllerFile.code.addMethod(
+      CsharpSupport.method({
+        name: "ExportToCsv",
+        access: "public",
+        isAsync: true,
+        returnType: CsharpSupport.Types.task(CsharpSupport.Types.reference("IActionResult")),
+        decorators: [
+          CsharpSupport.decorator({
+            name: "HttpGet",
+            arguments: ["export-csv"],
+          }),
+        ],
+        body: `
+          var allItems = await _service.List();
+          var csv = ConvertToCsv(allItems);
+          return File(Encoding.UTF8.GetBytes(csv), "text/csv", "${entity.name}Export.csv");
+        `,
+      })
     );
 
-    files.set({
-      path: controllerPath,
-      code: updatedCode
-    });
+    // Add necessary imports
+    controllerFile.code.addImport("System.Text");
+    controllerFile.code.addImport("Microsoft.AspNetCore.Mvc");
   }
 
   return files;

--- a/docs/plugins/dotnet-plugin-events/create-entity-controller.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-controller.md
@@ -48,11 +48,11 @@ Example:
 async afterCreateEntityController(
   context: DsgContext,
   eventParams: CreateEntityControllerParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, resourceName, apisDir } = eventParams;
   const controllerPath = join(apisDir, `${resourceName}Controller.cs`);
-  const controllerFile = modules.get(controllerPath);
+  const controllerFile = files.get(controllerPath);
 
   if (controllerFile) {
     const updatedCode = controllerFile.code.replace(
@@ -60,12 +60,12 @@ async afterCreateEntityController(
       "[ApiVersion(\"1.0\")]\npublic class"
     );
 
-    modules.set({
+    files.set({
       path: controllerPath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-extensions.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-extensions.md
@@ -31,11 +31,11 @@ Example:
 async afterCreateEntityExtensions(
   context: DsgContext,
   eventParams: CreateEntityExtensionsParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, apisDir } = eventParams;
   const extensionsPath = join(apisDir, "Extensions", `${entity.name}Extensions.cs`);
-  const extensionsFile = modules.get(extensionsPath);
+  const extensionsFile = files.get(extensionsPath);
 
   if (extensionsFile) {
     const updatedCode = extensionsFile.code + `
@@ -45,12 +45,12 @@ async afterCreateEntityExtensions(
     }
     `;
 
-    modules.set({
+    files.set({
       path: extensionsPath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-extensions.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-extensions.md
@@ -25,30 +25,61 @@ export interface CreateEntityExtensionsParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityExtensions(
-  context: DsgContext,
-  eventParams: CreateEntityExtensionsParams,
-  files: FileMap<F>
-) {
-  const { entity, apisDir } = eventParams;
-  const extensionsPath = join(apisDir, "Extensions", `${entity.name}Extensions.cs`);
+afterCreateEntityExtensions(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityExtensionsParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const { entity, resourceName, apisDir } = eventParams;
+  const extensionsPath = `${apisDir}/${entity.name}/${pascalCase(entity.name)}Extensions.cs`;
   const extensionsFile = files.get(extensionsPath);
 
   if (extensionsFile) {
-    const updatedCode = extensionsFile.code + `
-    public static string GetDisplayName(this ${entity.name} entity)
-    {
-        return $"{entity.FirstName} {entity.LastName}";
-    }
-    `;
+    // Add a custom extension method
+    extensionsFile.code.addMethod(
+      CsharpSupport.method({
+        name: "ToAuditString",
+        isStatic: true,
+        returnType: CsharpSupport.Types.string(),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "this",
+            type: CsharpSupport.Types.reference(entity.name),
+            isThis: true,
+          }),
+        ],
+        body: `
+          return $"{entity.Id}|{entity.CreatedAt}|{entity.UpdatedAt}";
+        `,
+      })
+    );
 
-    files.set({
-      path: extensionsPath,
-      code: updatedCode
-    });
+    // Add a custom mapper extension
+    extensionsFile.code.addMethod(
+      CsharpSupport.method({
+        name: "ToDto",
+        isStatic: true,
+        returnType: CsharpSupport.Types.reference(`${entity.name}Dto`),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "this",
+            type: CsharpSupport.Types.reference(entity.name),
+            isThis: true,
+          }),
+        ],
+        body: `
+          return new ${entity.name}Dto
+          {
+            Id = entity.Id,
+            // Map other properties here
+            AuditString = entity.ToAuditString()
+          };
+        `,
+      })
+    );
   }
 
   return files;

--- a/docs/plugins/dotnet-plugin-events/create-entity-interface.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-interface.md
@@ -28,29 +28,24 @@ export interface CreateEntityInterfaceParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityInterface(
-  context: DsgContext,
-  eventParams: CreateEntityInterfaceParams,
-  files: FileMap<F>
-) {
-  const { entity, apisDir } = eventParams;
-  const interfacePath = join(apisDir, "Interfaces", `I${entity.name}.cs`);
-  const interfaceFile = files.get(interfacePath);
-
+afterCreateEntityInterface(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityInterfaceParams,
+  files: FileMap<Interface>
+): Promise<FileMap<Interface>> {
+  const { entity } = eventParams;
+  const interfaceFile = files.get(`Interfaces/I${entity.name}.cs`);
   if (interfaceFile) {
-    const updatedCode = interfaceFile.code + `
-    Task<bool> IsUnique(string name);
-    `;
-
-    files.set({
-      path: interfacePath,
-      code: updatedCode
-    });
+    interfaceFile.code.addMethod(
+      CsharpSupport.method({
+        name: "Validate",
+        returnType: CsharpSupport.Types.boolean(),
+      })
+    );
   }
-
   return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-interface.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-interface.md
@@ -34,23 +34,23 @@ Example:
 async afterCreateEntityInterface(
   context: DsgContext,
   eventParams: CreateEntityInterfaceParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, apisDir } = eventParams;
   const interfacePath = join(apisDir, "Interfaces", `I${entity.name}.cs`);
-  const interfaceFile = modules.get(interfacePath);
+  const interfaceFile = files.get(interfacePath);
 
   if (interfaceFile) {
     const updatedCode = interfaceFile.code + `
     Task<bool> IsUnique(string name);
     `;
 
-    modules.set({
+    files.set({
       path: interfacePath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-model.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-model.md
@@ -32,11 +32,11 @@ Example:
 async afterCreateEntityModel(
   context: DsgContext,
   eventParams: CreateEntityModelParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, resourceName, apisDir } = eventParams;
   const modelPath = join(apisDir, "Models", `${resourceName}.cs`);
-  const modelFile = modules.get(modelPath);
+  const modelFile = files.get(modelPath);
 
   if (modelFile) {
     const updatedCode = modelFile.code.replace(
@@ -44,12 +44,12 @@ async afterCreateEntityModel(
       "[Table(\"" + entity.name + "\")]\npublic class"
     );
 
-    modules.set({
+    files.set({
       path: modelPath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-model.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-model.md
@@ -26,30 +26,24 @@ export interface CreateEntityModelParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityModel(
-  context: DsgContext,
-  eventParams: CreateEntityModelParams,
-  files: FileMap<F>
-) {
-  const { entity, resourceName, apisDir } = eventParams;
-  const modelPath = join(apisDir, "Models", `${resourceName}.cs`);
-  const modelFile = files.get(modelPath);
-
+afterCreateEntityModel(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityModelParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const { entity, resourceName } = eventParams;
+  const modelFile = files.get(`${resourceName}/Models/${entity.name}.cs`);
   if (modelFile) {
-    const updatedCode = modelFile.code.replace(
-      "public class",
-      "[Table(\"" + entity.name + "\")]\npublic class"
+    modelFile.code.addAttribute(
+      CsharpSupport.attribute({
+        name: "Table",
+        arguments: [`"${entity.name}s"`],
+      })
     );
-
-    files.set({
-      path: modelPath,
-      code: updatedCode
-    });
   }
-
   return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-service-base.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-service-base.md
@@ -27,32 +27,32 @@ export interface CreateEntityServiceBaseParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityServiceBase(
-  context: DsgContext,
-  eventParams: CreateEntityServiceBaseParams,
-  files: FileMap<F>
-) {
-  const { resourceName, apisDir } = eventParams;
-  const serviceBasePath = join(apisDir, `${resourceName}ServiceBase.cs`);
-  const serviceBaseFile = files.get(serviceBasePath);
-
+afterCreateEntityServiceBase(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityServiceBaseParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const { entity } = eventParams;
+  const serviceBaseFile = files.get(`Services/Base/${entity.name}ServiceBase.cs`);
   if (serviceBaseFile) {
-    const updatedCode = serviceBaseFile.code + `
-    protected async Task<bool> EntityExists(int id)
-    {
-        return await _context.Set<TEntity>().AnyAsync(e => e.Id == id);
-    }
-    `;
-
-    files.set({
-      path: serviceBasePath,
-      code: updatedCode
-    });
+    serviceBaseFile.code.addMethod(
+      CsharpSupport.method({
+        name: "SoftDelete",
+        access: "protected",
+        returnType: CsharpSupport.Types.task(CsharpSupport.Types.void()),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "id",
+            type: CsharpSupport.Types.string(),
+          }),
+        ],
+        body: "// Implement soft delete logic here",
+      })
+    );
   }
-
   return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-service-base.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-service-base.md
@@ -33,11 +33,11 @@ Example:
 async afterCreateEntityServiceBase(
   context: DsgContext,
   eventParams: CreateEntityServiceBaseParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { resourceName, apisDir } = eventParams;
   const serviceBasePath = join(apisDir, `${resourceName}ServiceBase.cs`);
-  const serviceBaseFile = modules.get(serviceBasePath);
+  const serviceBaseFile = files.get(serviceBasePath);
 
   if (serviceBaseFile) {
     const updatedCode = serviceBaseFile.code + `
@@ -47,12 +47,12 @@ async afterCreateEntityServiceBase(
     }
     `;
 
-    modules.set({
+    files.set({
       path: serviceBasePath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-service.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-service.md
@@ -32,11 +32,11 @@ Example:
 async afterCreateEntityService(
   context: DsgContext,
   eventParams: CreateEntityServiceParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { entity, resourceName, apisDir } = eventParams;
   const servicePath = join(apisDir, `${resourceName}Service.cs`);
-  const serviceFile = modules.get(servicePath);
+  const serviceFile = files.get(servicePath);
 
   if (serviceFile) {
     const updatedCode = serviceFile.code + `
@@ -47,12 +47,12 @@ async afterCreateEntityService(
     }
     `;
 
-    modules.set({
+    files.set({
       path: servicePath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-entity-service.md
+++ b/docs/plugins/dotnet-plugin-events/create-entity-service.md
@@ -26,31 +26,47 @@ export interface CreateEntityServiceParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateEntityService(
-  context: DsgContext,
-  eventParams: CreateEntityServiceParams,
-  files: FileMap<F>
-) {
+afterCreateEntityService(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateEntityServiceParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
   const { entity, resourceName, apisDir } = eventParams;
-  const servicePath = join(apisDir, `${resourceName}Service.cs`);
+  const servicePath = `${apisDir}/${entity.name}/${pascalCase(entity.name)}Service.cs`;
   const serviceFile = files.get(servicePath);
 
   if (serviceFile) {
-    const updatedCode = serviceFile.code + `
-    public async Task<${entity.name}> CustomOperation(int id)
-    {
-        // Add custom business logic here
-        return await _context.${entity.pluralName}.FindAsync(id);
-    }
-    `;
+    // Add a custom method to the service
+    serviceFile.code.addMethod(
+      CsharpSupport.method({
+        name: "GetRecentlyModified",
+        access: "public",
+        isAsync: true,
+        returnType: CsharpSupport.Types.task(CsharpSupport.Types.list(CsharpSupport.Types.reference(entity.name))),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "days",
+            type: CsharpSupport.Types.int(),
+            defaultValue: "7",
+          }),
+        ],
+        body: `
+          var cutoffDate = DateTime.UtcNow.AddDays(-days);
+          return await _repository.GetAll()
+            .Where(e => e.UpdatedAt >= cutoffDate)
+            .OrderByDescending(e => e.UpdatedAt)
+            .ToListAsync();
+        `,
+      })
+    );
 
-    files.set({
-      path: servicePath,
-      code: updatedCode
-    });
+    // Add necessary imports
+    serviceFile.code.addImport("System");
+    serviceFile.code.addImport("System.Linq");
+    serviceFile.code.addImport("Microsoft.EntityFrameworkCore");
   }
 
   return files;

--- a/docs/plugins/dotnet-plugin-events/create-message-broker-client-options-factory.md
+++ b/docs/plugins/dotnet-plugin-events/create-message-broker-client-options-factory.md
@@ -22,3 +22,27 @@ export interface CreateMessageBrokerClientOptionsFactoryParams extends EventPara
 ```
 
 This event does not use any additional parameters.
+
+### Example
+
+
+```ts
+afterCreateMessageBrokerClientOptionsFactory(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateMessageBrokerClientOptionsFactoryParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const optionsFactoryFile = files.get("MessageBroker/MessageBrokerClientOptionsFactory.cs");
+  if (optionsFactoryFile) {
+    optionsFactoryFile.code.addMethod(
+      CsharpSupport.method({
+        name: "CreateConsumerConfig",
+        access: "public",
+        returnType: CsharpSupport.Types.reference("ConsumerConfig"),
+        body: "return new ConsumerConfig { GroupId = \"my-consumer-group\" };",
+      })
+    );
+  }
+  return files;
+}
+```

--- a/docs/plugins/dotnet-plugin-events/create-message-broker-service.md
+++ b/docs/plugins/dotnet-plugin-events/create-message-broker-service.md
@@ -22,3 +22,17 @@ export interface CreateMessageBrokerServiceParams extends EventParams {}
 ```
 
 This event does not use any additional parameters.
+
+### Example
+
+```ts
+async afterCreateMessageBrokerService(
+  dsgContext: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateMessageBrokerServiceParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const messageBrokerFiles = await createMessageBroker(dsgContext);
+  await files.merge(messageBrokerFiles);
+  return files;
+}
+```

--- a/docs/plugins/dotnet-plugin-events/create-resource-db-context-file.md
+++ b/docs/plugins/dotnet-plugin-events/create-resource-db-context-file.md
@@ -31,10 +31,10 @@ Example:
 async afterCreateResourceDbContextFile(
   context: DsgContext,
   eventParams: CreateResourceDbContextFileParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { resourceName, resourceDbContextPath } = eventParams;
-  const dbContextFile = modules.get(resourceDbContextPath);
+  const dbContextFile = files.get(resourceDbContextPath);
 
   if (dbContextFile) {
     const updatedCode = dbContextFile.code.replace(
@@ -48,12 +48,12 @@ async afterCreateResourceDbContextFile(
     }
     `;
 
-    modules.set({
+    files.set({
       path: resourceDbContextPath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-resource-db-context-file.md
+++ b/docs/plugins/dotnet-plugin-events/create-resource-db-context-file.md
@@ -25,34 +25,34 @@ export interface CreateResourceDbContextFileParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
-async afterCreateResourceDbContextFile(
-  context: DsgContext,
-  eventParams: CreateResourceDbContextFileParams,
-  files: FileMap<F>
-) {
-  const { resourceName, resourceDbContextPath } = eventParams;
-  const dbContextFile = files.get(resourceDbContextPath);
+afterCreateResourceDbContextFile(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateResourceDbContextFileParams,
+  files: FileMap<Class>
+): FileMap<Class> {
+  const { resourceDbContextPath, resourceName } = eventParams;
 
-  if (dbContextFile) {
-    const updatedCode = dbContextFile.code.replace(
-      "public class",
-      "public class " + resourceName + "DbContext : DbContext\n{\n"
-    ) + `
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        base.OnModelCreating(modelBuilder);
-        // Add your custom configurations here
-    }
-    `;
+  const modelFile = files.get(
+    `${resourceDbContextPath}${resourceName}DbContext.cs`
+  );
 
-    files.set({
-      path: resourceDbContextPath,
-      code: updatedCode
-    });
-  }
+  if (!modelFile) return files;
+
+  modelFile.code.parentClassReference = CsharpSupport.genericClassReference({
+    reference: CsharpSupport.classReference({
+      name: `IdentityDbContext`,
+      namespace: "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
+    }),
+    innerType: CsharpSupport.Types.reference(
+      CsharpSupport.classReference({
+        name: `IdentityUser`,
+        namespace: "Microsoft.AspNetCore.Identity",
+      })
+    ),
+  });
 
   return files;
 }

--- a/docs/plugins/dotnet-plugin-events/create-seed-development-data-file.md
+++ b/docs/plugins/dotnet-plugin-events/create-seed-development-data-file.md
@@ -30,10 +30,10 @@ Example:
 async afterCreateSeedDevelopmentDataFile(
   context: DsgContext,
   eventParams: CreateSeedDevelopmentDataFileParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { seedFilePath, resourceName } = eventParams;
-  const seedFile = modules.get(seedFilePath);
+  const seedFile = files.get(seedFilePath);
 
   if (seedFile) {
     const updatedCode = seedFile.code + `
@@ -50,12 +50,12 @@ async afterCreateSeedDevelopmentDataFile(
     }
     `;
 
-    modules.set({
+    files.set({
       path: seedFilePath,
       code: updatedCode
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-server-appsettings.md
+++ b/docs/plugins/dotnet-plugin-events/create-server-appsettings.md
@@ -23,23 +23,22 @@ export interface CreateServerAppsettingsParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
 beforeCreateServerAppsettings(
-  context: DsgContext,
-  eventParams: CreateServerAppsettingsParams
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateServerAppsettingsParams
 ) {
+  const { port, password, user, host, dbName } = getPluginSettings(
+    context.pluginInstallations
+  );
+
   eventParams.updateProperties = {
     ...eventParams.updateProperties,
-    "Logging": {
-      "LogLevel": {
-        "Default": "Information",
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
+    ConnectionStrings: {
+      [CONNECTION_STRING]: `Host=${host}:${port};Username=${user};Password=${password};Database=${dbName}`,
     },
-    "AllowedHosts": "*"
   };
   return eventParams;
 }

--- a/docs/plugins/dotnet-plugin-events/create-server-auth.md
+++ b/docs/plugins/dotnet-plugin-events/create-server-auth.md
@@ -22,3 +22,32 @@ export interface CreateServerAuthParams extends EventParams {}
 ```
 
 This event does not use any additional parameters.
+
+### Example
+
+```ts
+afterCreateServerAuth(
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateServerAuthParams,
+  files: FileMap<Class>
+): Promise<FileMap<Class>> {
+  const authFile = files.get("Auth/AuthService.cs");
+  if (authFile) {
+    authFile.code.addMethod(
+      CsharpSupport.method({
+        name: "ValidateToken",
+        access: "public",
+        returnType: CsharpSupport.Types.boolean(),
+        parameters: [
+          CsharpSupport.parameter({
+            name: "token",
+            type: CsharpSupport.Types.string(),
+          }),
+        ],
+        body: "// Add token validation logic here\nreturn true;",
+      })
+    );
+  }
+  return files;
+}
+```

--- a/docs/plugins/dotnet-plugin-events/create-server-csproj.md
+++ b/docs/plugins/dotnet-plugin-events/create-server-csproj.md
@@ -29,22 +29,16 @@ export interface CreateServerCsprojParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
 beforeCreateServerCsproj(
-  context: DsgContext,
-  eventParams: CreateServerCsprojParams
+  _: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateServerCsprojParams
 ) {
-  eventParams.propertyGroup = {
-    ...eventParams.propertyGroup,
-    "TargetFramework": "net6.0",
-    "ImplicitUsings": "enable"
-  };
-
   eventParams.packageReferences.push({
-    include: "Swashbuckle.AspNetCore",
-    version: "6.2.3"
+    include: "Npgsql.EntityFrameworkCore.PostgreSQL",
+    version: "8.0.4",
   });
 
   return eventParams;

--- a/docs/plugins/dotnet-plugin-events/create-server-docker-compose.md
+++ b/docs/plugins/dotnet-plugin-events/create-server-docker-compose.md
@@ -25,23 +25,18 @@ export interface CreateServerDockerComposeParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
 beforeCreateServerDockerCompose(
-  context: DsgContext,
-  eventParams: CreateServerDockerComposeParams
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateServerDockerComposeParams
 ) {
-  const additionalServices = {
-    services: {
-      redis: {
-        image: "redis:alpine",
-        ports: ["6379:6379"]
-      }
-    }
-  };
+  const settings = getPluginSettings(context.pluginInstallations);
 
-  eventParams.updateProperties.push(additionalServices);
+  eventParams.updateProperties.push(
+    ...updateDockerComposeProperties(settings)
+  );
   return eventParams;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/create-server-git-ignore.md
+++ b/docs/plugins/dotnet-plugin-events/create-server-git-ignore.md
@@ -23,17 +23,18 @@ export interface CreateServerGitIgnoreParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
 beforeCreateServerGitIgnore(
-  context: DsgContext,
-  eventParams: CreateServerGitIgnoreParams
-) {
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.CreateServerGitIgnoreParams
+): Promise<dotnet.CreateServerGitIgnoreParams> {
   eventParams.gitignorePaths.push(
     "*.user",
     "*.userosscache",
-    "*.sln.docstates"
+    "*.sln.docstates",
+    "[Tt]est[Rr]esult*"
   );
   return eventParams;
 }

--- a/docs/plugins/dotnet-plugin-events/load-static-files.md
+++ b/docs/plugins/dotnet-plugin-events/load-static-files.md
@@ -30,19 +30,19 @@ Example:
 async afterLoadStaticFiles(
   context: DsgContext,
   eventParams: LoadStaticFilesParams,
-  modules: ModuleMap
+  files: FileMap<F>
 ) {
   const { source, basePath } = eventParams;
   const staticFiles = await readDir(source);
   
   for (const file of staticFiles) {
     const content = await readFile(join(source, file));
-    modules.set({
+    files.set({
       path: join(basePath, file),
       code: content
     });
   }
 
-  return modules;
+  return files;
 }
 ```

--- a/docs/plugins/dotnet-plugin-events/load-static-files.md
+++ b/docs/plugins/dotnet-plugin-events/load-static-files.md
@@ -24,25 +24,37 @@ export interface LoadStaticFilesParams extends EventParams {
 }
 ```
 
-Example:
+### Example
 
 ```ts
 async afterLoadStaticFiles(
-  context: DsgContext,
-  eventParams: LoadStaticFilesParams,
-  files: FileMap<F>
-) {
-  const { source, basePath } = eventParams;
-  const staticFiles = await readDir(source);
-  
-  for (const file of staticFiles) {
-    const content = await readFile(join(source, file));
-    files.set({
-      path: join(basePath, file),
-      code: content
-    });
-  }
+  context: dotnetTypes.DsgContext,
+  eventParams: dotnet.LoadStaticFilesParams,
+  files: FileMap<CodeBlock>
+): Promise<FileMap<CodeBlock>> {
+  const { resourceInfo } = context;
+  if (!resourceInfo) return files;
 
+  const resourceName = pascalCase(resourceInfo.name);
+
+  const destPath = `${eventParams.basePath}/src/APIs/Common/Auth/ProgramAuthExtensions.cs`;
+  const filePath = resolve(
+    __dirname,
+    "./static/common/auth/ProgramAuthExtensions.cs"
+  );
+
+  const programAuthExtensionsFileMap = await createStaticFileFileMap(
+    destPath,
+    filePath,
+    context,
+    [
+      CsharpSupport.classReference({
+        name: `${resourceName}DbContext`,
+        namespace: `${resourceName}.Infrastructure`,
+      }),
+    ]
+  );
+  
   return files;
 }
 ```


### PR DESCRIPTION
1. Updating the .NET Event examples that use the `after` function so that they're correct.
2. Updating the Before and After Lifecycle Functions page so that it's a more clear explanations on the differences between the Node.js and .NET DSG.